### PR TITLE
Declare dependency on Emacs 24

### DIFF
--- a/wolfram-mode.el
+++ b/wolfram-mode.el
@@ -7,6 +7,7 @@
 ;; Created: 2009-07-08
 ;; Modified: 2013-11-23
 ;; Keywords: languages, processes, tools
+;; Package-Requires: ((emacs "24"))
 ;; Namespace: wolfram-
 ;; URL: https://github.com/kawabata/wolfram-mode/
 


### PR DESCRIPTION
This file specifies `lexical-binding`, and is therefore
presumably only usable in Emacs >= 24. This commit adds
a corresponding `Package-Requires` declaration.
