### PR TITLE
Fix package header

### DIFF
--- a/wolfram-mode.el
+++ b/wolfram-mode.el
@@ -1,4 +1,4 @@
-;; * wolfram-mode.el --- Mathematica editing and inferior mode.  -*- lexical-binding: t -*-
+;;; wolfram-mode.el --- Mathematica editing and inferior mode.  -*- lexical-binding: t -*-
 
 ;; Filename: wolfram-mode.el
 ;; Description: Wolfram Language (Mathematica) editing and inferior Mode


### PR DESCRIPTION
Modify the first line of the package header to match the expected format:

    ;;; filename --- description

As suggested at https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers

Currently, the package shows up on MELPA with a description of "No description available."